### PR TITLE
fix: rename `gr2m/logflare-log-action` to `logflare/action`

### DIFF
--- a/.github/workflows/log-pull-request.yml
+++ b/.github/workflows/log-pull-request.yml
@@ -16,4 +16,9 @@ jobs:
           api_key: ${{ secrets.LOGFLARE_API_KEY }}
           source_id: ${{ secrets.LOGFLARE_SOURCE_ID }}
           message: "pull request ${{ github.event.action }}: ${{ github.event.pull_request.html_url }}"
-          metadata: ${{ toJSON(github.event) }}
+          # github.event pull_request payload example:
+          # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
+          metadata: |
+            {
+              "version": "${{ github.event.release.tag_name }}"
+            }

--- a/.github/workflows/log-pull-request.yml
+++ b/.github/workflows/log-pull-request.yml
@@ -17,8 +17,11 @@ jobs:
           source_id: ${{ secrets.LOGFLARE_SOURCE_ID }}
           message: "pull request ${{ github.event.action }}: ${{ github.event.pull_request.html_url }}"
           # github.event pull_request payload example:
-          # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
+          # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-30
           metadata: |
             {
-              "version": "${{ github.event.release.tag_name }}"
+              "action": "${{ github.event.action }}",
+              "created_by": "${{ github.event.pull_request.user.login }}",
+              "head": "${{ github.event.pull_request.head.label }}",
+              "base": "${{ github.event.pull_request.base.label }}"
             }

--- a/.github/workflows/log-release.yml
+++ b/.github/workflows/log-release.yml
@@ -16,4 +16,12 @@ jobs:
           api_key: ${{ secrets.LOGFLARE_API_KEY }}
           source_id: ${{ secrets.LOGFLARE_SOURCE_ID }}
           message: "new release: ${{ github.event.release.html_url }}"
-          metadata: ${{ toJSON(github.event) }}
+          # github.event release payload example:
+          # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-34
+          metadata: |
+            {
+              "action": "${{ github.event.action }}",
+              "created_by": "${{ github.event.user.login }}",
+              "head": "${{ github.event.head.label }}",
+              "base": "${{ github.event.base.label }}"
+            }

--- a/.github/workflows/log-release.yml
+++ b/.github/workflows/log-release.yml
@@ -20,8 +20,5 @@ jobs:
           # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-34
           metadata: |
             {
-              "action": "${{ github.event.action }}",
-              "created_by": "${{ github.event.user.login }}",
-              "head": "${{ github.event.head.label }}",
-              "base": "${{ github.event.base.label }}"
+              "version": "${{ github.event.release.tag_name }}"
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm run build
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GR2M_PAT_FOR_SEMANTIC_RELEASE }}
+          GITHUB_TOKEN: ${{ secrets.CHASERS_ACTION_SECRET }}
       - run: "git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at opensource+octokit@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support+opensource@logflare.app. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,19 @@ The action requires four environment variables to be set
 ```
 INPUT_API_KEY=yourapikey INPUT_SOURCE_ID=yoursourceid INPUT_MESSAGE="my message" INPUT_METADATA='{"data":"here"}' node index.js
 ```
+
+## Maintainers only: releasing a new version
+
+Releases are automated using [semantic-release](https://github.com/semantic-release/semantic-release) when ever a push occurs on the `main` branch. The following commit message conventions determine which version is released:
+
+1. `fix: ...` or `fix(scope name): ...` prefix in subject: bumps fix version, e.g. `1.2.3` → `1.2.4`
+2. `feat: ...` or `feat(scope name): ...` prefix in subject: bumps feature version, e.g. `1.2.3` → `1.3.0`
+3. `BREAKING CHANGE:` in body: bumps breaking version, e.g. `1.2.3` → `2.0.0`
+
+If a pull request looks good but does not follow the commit conventions, use the "Squash & merge" button to update the commit message when merging.
+
+Only one version number is bumped at a time, the highest version change trumps the others.
+Besides publishing a new version to npm, semantic-release also creates a git tag and release
+on GitHub, generates changelogs from the commit messages and puts them into the release notes.
+
+It also builds the code into a single binary and pushes the update to the `v1` branch. That ways users get fix/feature updates automatically when they use `uses: logflare/action@v1` in their workflow file.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > GitHub Action to create a log in a [Logflare](https://logflare.app/) source
 
-[![Build Status](https://github.com/gr2m/logflare-log-action/workflows/Test/badge.svg)](https://github.com/gr2m/logflare-log-action/actions)
+[![Build Status](https://github.com/logflare/action/workflows/Test/badge.svg)](https://github.com/logflare/action/actions)
 
 ## Usage
 
@@ -23,7 +23,7 @@ jobs:
   log:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/logflare-log-action@v1
+      - uses: logflare/action@v1
         id: stats
         with:
           api_key: ${{ secrets.LOGFLARE_API_KEY }}

--- a/lib/send-log.js
+++ b/lib/send-log.js
@@ -14,6 +14,9 @@ async function sendLog(core) {
   const url = `https://api.logflare.app/logs?api_key=${api_key}&source=${source_id}`;
   const json = { log_entry, metadata };
 
+  core.debug("Sending log ...");
+  core.debug(json);
+
   const { statusCode, statusMessage, body } = await post(url, { json });
 
   if (statusCode !== 200) {
@@ -24,7 +27,7 @@ async function sendLog(core) {
     throw error;
   }
 
-  core.info("Log message sent");
+  core.info("Log message sent.");
   core.debug("Response from Logflare:");
   core.debug(body);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "action"
   ],
-  "repository": "https://github.com/gr2m/logflare-log-action",
+  "repository": "https://github.com/logflare/action",
   "author": "Gregor Martynus (https://twitter.com/gr2m)",
   "license": "MIT",
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -35,8 +35,18 @@ test("README example", async function () {
 
   await sendLog(coreMock).catch(console.log);
 
-  assert.equal(infoLogs, ["Log message sent"]);
-  assert.equal(debugLogs, ["Response from Logflare:", '{"message":"Logged!"}']);
+  assert.equal(infoLogs, ["Log message sent."]);
+  assert.equal(debugLogs, [
+    "Sending log ...",
+    {
+      log_entry: "my log message",
+      metadata: {
+        meta: "data",
+      },
+    },
+    "Response from Logflare:",
+    '{"message":"Logged!"}',
+  ]);
 });
 
 test.run();


### PR DESCRIPTION
- [x] accept invitation https://github.com/gr2m/logflare-log-action/invitations
- [x] transfer repository to https://github.com/logflare
- [x] create new personal access token for automated releases, then update https://github.com/Logflare/logflare-log-action/blob/1f1622719f296c713a9d1fea35b975a9f7964b4a/.github/workflows/release.yml#L17
- [x] create secrets: `LOGFLARE_API_KEY`, `LOGFLARE_SOURCE_ID`
- [x] rename repository to `action`
- [x] update email in `CODE_OF_CONDUCT.md` or remove the file if you prefer
- [x] Change the `LICENSE` if you like

@chasers ☝️